### PR TITLE
[14.0][FIX] l10n_es_aeat_mod322_special_prorate_regularization_capital_asset: require asset type

### DIFF
--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/__manifest__.py
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "AEAT 303 - Special Prorate Regularization Capital Asset",
     "summary": "This module allows to regularize capital assets "
     "prorate differences on 322 report",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Accounting",
     "author": "Dixmit",
     "website": "https://github.com/oxigensalud/odoo-community-addons",

--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/i18n/ca.po
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/i18n/ca.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_aeat_mod322_special_prorate_regularization_capital_asset
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-22 00:00+0000\n"
+"PO-Revision-Date: 2026-05-22 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_es_aeat_mod322_special_prorate_regularization_capital_asset
+#: code:addons/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/models/mod322.py:0
+#, python-format
+msgid ""
+"The following assets require a capital asset type before creating the "
+"capital asset prorate regularization: %s"
+msgstr ""
+"Els actius seguents requereixen un tipus de be d'inversio abans de crear la "
+"regularitzacio de prorrata de bens d'inversio: %s"

--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/i18n/es.po
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/i18n/es.po
@@ -187,6 +187,16 @@ msgstr "Línea de reparto encontrada en el activo %s impuesto %s"
 msgid "The account move cannot be created because it already exists"
 msgstr "El asiento contable no puede ser creado porque ya existe"
 
+#. module: l10n_es_aeat_mod322_special_prorate_regularization_capital_asset
+#: code:addons/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/models/mod322.py:0
+#, python-format
+msgid ""
+"The following assets require a capital asset type before creating the "
+"capital asset prorate regularization: %s"
+msgstr ""
+"Los siguientes activos requieren un tipo de bien de inversión antes de crear "
+"la regularización de prorrata de bienes de inversión: %s"
+
 #. module: l10n_es_aeat_mod303_special_prorate_regularization_capital_asset
 #: code:addons/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py:0
 #, python-format

--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/models/mod322.py
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/models/mod322.py
@@ -128,6 +128,10 @@ class L10nEsAeatMod322Report(models.AbstractModel):
         precision = self.env["decimal.precision"].precision_get("Account")
         lines = []
         move_lines_values = self._prepare_move_lines(tax_lines)
+        assets = self.env["account.asset"].browse(
+            [x["asset_id"][0] for x in move_lines_values]
+        )
+        self._check_assets_have_capital_asset_type(assets)
         for move_line in move_lines_values:
             asset = self.env["account.asset"].browse(move_line["asset_id"][0])
             percent_diff = (
@@ -221,7 +225,19 @@ class L10nEsAeatMod322Report(models.AbstractModel):
         )
         return tax_line_vals
 
+    def _check_assets_have_capital_asset_type(self, assets):
+        missing_assets = assets.filtered(lambda x: not x.capital_asset_type_id)
+        if missing_assets:
+            raise UserError(
+                _(
+                    "The following assets require a capital asset type before "
+                    "creating the capital asset prorate regularization: %s"
+                )
+                % ", ".join(missing_assets.mapped("display_name"))
+            )
+
     def _calculate_amount(self, assets_to_regularize, tax_final_percentage):
+        self._check_assets_have_capital_asset_type(assets_to_regularize)
         precision = self.env["decimal.precision"].precision_get("Account")
         amount = 0
         for asset in assets_to_regularize:

--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/tests/test_mod322_prorate.py
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/tests/test_mod322_prorate.py
@@ -151,7 +151,13 @@ class TestL10nEsAeatMod322Base(TestL10nEsAeatModBase):
     def setUpClass(cls):
         super().setUpClass()
         # Create model
-        cls.company.write({"vat": "1234567890", "l10n_es_prorate_enabled": True})
+        cls.company.write(
+            {
+                "vat": "1234567890",
+                "l10n_es_prorate_enabled": True,
+                "l10n_es_capital_asset_enabled": True,
+            }
+        )
         cls.prorrate_map_2022 = cls.env["aeat.map.special.prorrate.year"].create(
             {
                 "year": 2022,

--- a/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/tests/test_mod322_prorate_no_changes.py
+++ b/l10n_es_aeat_mod322_special_prorate_regularization_capital_asset/tests/test_mod322_prorate_no_changes.py
@@ -151,7 +151,13 @@ class TestL10nEsAeatMod322Base(TestL10nEsAeatModBase):
     def setUpClass(cls):
         super().setUpClass()
         # Create model
-        cls.company.write({"vat": "1234567890", "l10n_es_prorate_enabled": True})
+        cls.company.write(
+            {
+                "vat": "1234567890",
+                "l10n_es_prorate_enabled": True,
+                "l10n_es_capital_asset_enabled": True,
+            }
+        )
         cls.prorrate_map_2022 = cls.env["aeat.map.special.prorrate.year"].create(
             {
                 "year": 2022,

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,7 @@ odoo14-addon-l10n_es_aeat_vat_special_prorrate@git+https://github.com/nuobit/odo
 odoo14-addon-l10n_es_aeat_mod303_special_prorate_regularization@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_aeat_mod303_special_prorate_regularization
 odoo14-addon-l10n_es_aeat_mod303_special_prorate_regularization_capital_asset@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset
 odoo14-addon-l10n_es_account_capital_asset@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_account_capital_asset
+odoo14-addon-l10n_es_account_capital_asset_tax_map_prorate@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_account_capital_asset_tax_map_prorate
 odoo14-addon-l10n_es_aeat_prorate_asset@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_aeat_prorate_asset
 odoo14-addon-l10n_es_asset_extension@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_asset_extension
 odoo14-addon-account_asset_management_extension@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/account_asset_management_extension


### PR DESCRIPTION
## Summary

- Guard model 322 capital-asset prorate regularization before reading `asset.capital_asset_type_id.period`.
- Raise a clear user-facing error listing assets that need a capital asset type.
- Bump the module version and add the new Catalan/Spanish translations.

## Rationale

The source asset set is normally filtered to assets with a capital asset type, but stale/manual tax lines or future call paths could still reach the regularization calculation without one. This makes the invariant explicit and avoids an uncontrolled `.period` access on an empty recordset.

## Validation

- Focused pre-commit passed for the changed Oxigen files.
