### PR TITLE
[14.0][IMP] l10n_es_aeat_mod322_special_prorate: map 322 2025 taxes

### DIFF
--- a/l10n_es_aeat_mod322_special_prorate/__manifest__.py
+++ b/l10n_es_aeat_mod322_special_prorate/__manifest__.py
@@ -12,9 +12,11 @@
     "depends": [
         "l10n_es_special_prorate",
         "l10n_es_aeat_mod322",
+        "l10n_es_aeat_mod322_extension",
     ],
     "data": [
         "data/tax_code_map_mod322_2023_data.xml",
+        "data/tax_code_map_mod322_2025_data.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/l10n_es_aeat_mod322_special_prorate/data/tax_code_map_mod322_2025_data.xml
+++ b/l10n_es_aeat_mod322_special_prorate/data/tax_code_map_mod322_2025_data.xml
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_21"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_22"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+            ]"
+        />
+
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_10_purchase"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+           ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_11_purchase"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+            ]"
+        />
+    </record>
+
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_25_purchase"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+           ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_26_purchase"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+            ]"
+        />
+    </record>
+
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_39"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_40"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_41"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_42"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field name="account_id" ref="l10n_es.account_common_472" />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_43"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva5_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_44"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva5_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+            ]"
+        />
+    </record>
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_45"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_46"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_47"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_48"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field name="account_id" ref="l10n_es.account_common_472" />
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi'))
+            ]"
+        />
+    </record>
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_49"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_50"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field name="account_id" ref="l10n_es.account_common_472" />
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc')),
+            ]"
+        />
+
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_51"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi'))
+            ]"
+        />
+
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_52"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi'))
+            ]"
+        />
+
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_53"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_54"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_55"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi'))
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_56"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi'))
+            ]"
+        />
+
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_57"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+            ]"
+        />
+    </record>
+
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_58"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field
+            name="tax_ids"
+            eval="[
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi')),
+                (4, ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in')),
+            ]"
+        />
+    </record>
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_60"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field name="to_regularize" eval="True" />
+        <field name="field_type">base</field>
+        <field
+            name="tax_ids"
+            eval="[(6, False, [
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi'),
+            ])]"
+        />
+    </record>
+    <record
+        id="l10n_es_aeat_mod322_extension.aeat_mod322_2025_map_line_61"
+        model="l10n.es.aeat.map.tax.line"
+    >
+        <field name="to_regularize" eval="True" />
+        <field name="account_id" ref="l10n_es.account_common_472" />
+        <field
+            name="tax_ids"
+            eval="[(6, False, [
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_ic_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_sc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva10_sp_in'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_ic_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_sc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva21_sp_in'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ibi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_ic_bi'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_sc'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva4_sp_in'),
+                ref('l10n_es_special_prorate.account_tax_template_p_priva5_sc'),
+            ])]"
+        />
+    </record>
+</odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,4 +8,6 @@ odoo14-addon-l10n_es_account_capital_asset_tax_map_prorate@git+https://github.co
 odoo14-addon-l10n_es_aeat_prorate_asset@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_aeat_prorate_asset
 odoo14-addon-l10n_es_asset_extension@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_asset_extension
 odoo14-addon-account_asset_management_extension@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/account_asset_management_extension
-odoo14-addon-l10n_es_extension@git+https://github.com/nuobit/odoo-addons.git@14.0#subdirectory=setup/l10n_es_extension
+odoo14-addon-l10n_es_extension@git+https://github.com/nuobit/odoo-addons.git@refs/pull/915/head#subdirectory=setup/l10n_es_extension
+odoo14-addon-l10n_es_aeat_mod322@git+https://github.com/OCA/l10n-spain.git@refs/pull/4005/head#subdirectory=setup/l10n_es_aeat_mod322
+odoo14-addon-l10n_es_aeat_mod322_extension@git+https://github.com/nuobit/odoo-addons.git@refs/pull/915/head#subdirectory=setup/l10n_es_aeat_mod322_extension


### PR DESCRIPTION
## Summary
- Apply the existing special-prorate 322 tax mappings to the new 2025 Modelo 322 map from `l10n_es_aeat_mod322_extension`.
- Add the temporary test dependency on NuoBiT PR 915 for the 2025 map module.

## Test plan
- [x] pre-commit run --files test-requirements.txt l10n_es_aeat_mod322_special_prorate/__manifest__.py l10n_es_aeat_mod322_special_prorate/data/tax_code_map_mod322_2025_data.xml
- [x] XML syntax check
- [x] 2025 XMLID reference existence check against PR 915 CSV data
- [ ] CI green
- [ ] Live Test1/Test5 322 comparison after deployment